### PR TITLE
Remove -force from write!

### DIFF
--- a/git_gutter.kak
+++ b/git_gutter.kak
@@ -10,7 +10,7 @@ hook global BufCreate .* gitdiff
 
 define-command -hidden gitdiff %{
     set-option buffer gitgutter_buffer %sh{ mktemp -t gitgutter.buffer.XXXXXX }
-    write! -force %opt{gitgutter_buffer}
+    write! %opt{gitgutter_buffer}
     evaluate-commands %sh{
     . "$kak_opt_git_gutter_sh_source"
     git_diff "${kak_opt_gitgutter_buffer}" "${kak_buffile}"


### PR DESCRIPTION
write! implies -force already, and in recent Kakoune versions, this fails entirely:

https://github.com/mawww/kakoune/commit/7ae31b6778fdf8129f4ccc0045e27c8389e53e18