### PR TITLE
Fix missing diffs when resolving conflicts

### DIFF
--- a/git_gutter.sh
+++ b/git_gutter.sh
@@ -164,7 +164,7 @@ git_diff()
     [ -e "${buffile}" ] \
         && cd "$(dirname "${buffile}")" \
         && temp_head=$(mktemp -t gitgutter.head.XXXXXX) \
-        && repo_relative_file="$(git ls-files --full-name $buffile)" \
+        && repo_relative_file="$(git ls-files --full-name $buffile | head -1)" \
         && git --no-pager show "HEAD:$repo_relative_file" > "$temp_head" \
         && diff_temp_files \
         || echo "set-option buffer git_diff_line_specs %val{timestamp}"


### PR DESCRIPTION
During a conflict, git ls-files may list the same file multiple times. ~~Pass --deduplicate to make sure this is avoided.~~ Only use the first one listed to avoid ending up with a nonsensical filename.
