### PR TITLE
Avoid running BufWrite* hooks for the temp file

### DIFF
--- a/git_gutter.kak
+++ b/git_gutter.kak
@@ -10,7 +10,7 @@ hook global BufCreate .* gitdiff
 
 define-command -hidden gitdiff %{
     set-option buffer gitgutter_buffer %sh{ mktemp -t gitgutter.buffer.XXXXXX }
-    write! %opt{gitgutter_buffer}
+    evaluate-commands -no-hooks %{ write! %opt{gitgutter_buffer} }
     evaluate-commands %sh{
     . "$kak_opt_git_gutter_sh_source"
     git_diff "${kak_opt_gitgutter_buffer}" "${kak_buffile}"


### PR DESCRIPTION
Because these hooks are generally used for things like formatting, they will end up modifying the active buffer when gitdiff writes its temporary file.